### PR TITLE
Apply syntax highlighting to JS code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Basta seguir os passos abaixo:
 
 3. Feito isso, agora copie o código abaixo e coloque no arquivo **card.js**: (inclua os seus dados!!)
 
-```
+```js
 #!/usr/bin/env node
 // Usado para dizer ao Node.js que se trata de uma ferramenta do CLI
 


### PR DESCRIPTION
Include language notation in the code notation, so that GitHub is able to apply the JavaScript
syntax highlighting, making it easier to read the documentation.